### PR TITLE
Bugfix: Array indexing did not work when the array was the last segment of the path

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "licenses": "MIT, GPL",
   "main": "src/index.js",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "dependencies": {},
   "devDependencies": {}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -40,20 +40,19 @@ function _set(key, val, tgt) {
 
     key = path.pop();
 
-
     for (i = 0, ii = path.length; i < ii; i++) {
         var arrayMatch = path[i].match(arrayMatchRegex);
         if (arrayMatch && arrayMatch.length > 2) {
             var propertyName = arrayMatch[1];
-            var arrayIndex = arrayMatch[2];
+            var arrayIndex = parseInt(arrayMatch[2]);
 
             if (!tgt[propertyName]) {
-                Vue.set(tgt, propertyName, {});
+                Vue.set(tgt, propertyName, []);
             }
-            if (!tgt[propertyName][parseInt(arrayIndex)]) {
+            if (!tgt[propertyName][arrayIndex]) {
                 Vue.set(tgt[propertyName], arrayIndex, {});
             }
-            tgt = tgt[propertyName][parseInt(arrayIndex)];
+            tgt = tgt[propertyName][arrayIndex];
         } else {
             if (!tgt[path[i]]) {
                 Vue.set(tgt, path[i], {});
@@ -62,13 +61,26 @@ function _set(key, val, tgt) {
         }
     }
 
-    if (_isObj(tgt[key]) && _isObj(val)) {
-        _merge(tgt[key], val);
+    var keyArrayMatch = key.match(arrayMatchRegex);
 
-        return;
+    if (keyArrayMatch && keyArrayMatch.length > 2) {
+        var propertyName = keyArrayMatch[1];
+        var arrayIndex = parseInt(keyArrayMatch[2]);
+
+        if (!tgt[propertyName]) {
+            Vue.set(tgt, propertyName, []);
+        }
+
+        Vue.set(tgt[propertyName], arrayIndex, val);
+    } else {
+        if (_isObj(tgt[key]) && _isObj(val)) {
+            _merge(tgt[key], val);
+
+            return;
+        }
+
+        Vue.set(tgt, key, val);
     }
-
-    Vue.set(tgt, key, val);
 }
 
 /**
@@ -90,15 +102,15 @@ function _get(key, tgt) {
         var arrayMatch = path[i].match(arrayMatchRegex);
         if (arrayMatch && arrayMatch.length > 2) {
             var propertyName = arrayMatch[1];
-            var arrayIndex = arrayMatch[2];
+            var arrayIndex = parseInt(arrayMatch[2]);
 
             if (!tgt[propertyName]) {
                return tgt[propertyName];
             }
-            if (!tgt[propertyName][parseInt(arrayIndex)]) {
-                return tgt[propertyName][parseInt(arrayIndex)];
+            if (!tgt[propertyName][arrayIndex]) {
+                return tgt[propertyName][arrayIndex];
             }
-            tgt = tgt[propertyName][parseInt(arrayIndex)];
+            tgt = tgt[propertyName][arrayIndex];
         } else {
             if (!tgt[path[i]]) {
                 return tgt[path[i]];


### PR DESCRIPTION
Array indexing did not work when the last segment of the path was the indexed array itself (e.g. this works: `_dot.set('some.array[0].aValue', ...)`, but this doesn't: `_dot.set('some.array[0]', ...)`).

Current behavior:
```javascript
_dot.set(`some.array[0]`, `test-value`, myObject);
// expected: myObject = { some: {array: ['test-value'] } }
// actual: myObject = { some: {'array[0]': 'test-value' } }
```

This PR fixes this issue so array indexing works as expected in those cases. Also fixes an issue where an object instead of an array was created during path-creation